### PR TITLE
feat: add tryExceptional method to Result class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.panfutov</groupId>
     <artifactId>jresult</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
 
     <description>
         A Java implementation of the Operation Result Pattern.

--- a/src/main/java/com/panfutov/result/Result.java
+++ b/src/main/java/com/panfutov/result/Result.java
@@ -250,6 +250,24 @@ public class Result<T> {
     }
 
     /**
+     * Performs an action in a try-catch block and returns a result object.
+     * In case of an exception it constructs a failure result with error that contains the throwable.
+     *
+     * @param action An action to execute.
+     * @param <T> a type parameter.
+     *
+     * @return Failure if an exception is caught. Otherwise, — success.
+     */
+    public static <T> Result<T> tryExceptional(Supplier<T> action) {
+        requireNonNull(action);
+        try {
+            return Result.success(action.get());
+        } catch (Throwable e) {
+            return Result.failure(Error.fromThrowable(e));
+        }
+    }
+
+    /**
      * A boolean status of an operation.
      * Could be true even if the errors are not empty (e.g. not critical errors).
      *

--- a/src/test/java/com/panfutov/result/ResultTest.java
+++ b/src/test/java/com/panfutov/result/ResultTest.java
@@ -225,6 +225,33 @@ class ResultTest {
     }
 
     @Test
+    void testTryExceptionalOnFailure() throws RuntimeException {
+        // WHEN
+        var result = Result.tryExceptional(() -> {
+            throw new RuntimeException(ERROR_TEXT);
+        });
+
+        // THEN
+        assertTrue(result.isFailure());
+        assertTrue(result.hasErrors());
+        assertEquals(ERROR_TEXT, result.firstError().getMessage());
+        assertNotNull(result.firstError().getThrowable());
+    }
+
+    @Test
+    void testTryExceptionalOnSuccess() {
+        // GIVEN
+        var input = 100;
+
+        // WHEN
+        var result = Result.tryExceptional(() -> input);
+
+        // THEN
+        assertTrue(result.isSuccess());
+        assertEquals(input, result.getNonNullObject());
+    }
+
+    @Test
     void testFailureWithMessageAndThrowable() {
         // WHEN
         var result = Result.failure(ERROR_TEXT, new RuntimeException());


### PR DESCRIPTION
The tryExceptional method is added to the Result class. This method allows performing an action in a try-catch block and returning a Result object. If an exception is caught, a failure result with an error containing the throwable is constructed. This method is useful for handling exceptions in a functional way.